### PR TITLE
Fix(cron): Make cron job creation idempotent

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -656,8 +656,14 @@ EOF
 
     chmod +x /usr/local/bin/vpn-monitor
 
-    # Monitoring cron job
-    echo "*/5 * * * * /usr/local/bin/vpn-monitor >> /var/log/vpn-monitor.log" | crontab -
+    # Monitoring cron job (idempotent)
+    MONITOR_JOB="*/5 * * * * /usr/local/bin/vpn-monitor >> /var/log/vpn-monitor.log"
+    CRON_CONTENT=$(crontab -l 2>/dev/null)
+    if ! echo "$CRON_CONTENT" | grep -Fq "$MONITOR_JOB"; then
+        # Safely append the new job and pipe to crontab.
+        # Using printf is safer than echo for multi-line variables.
+        printf "%s\n%s\n" "$CRON_CONTENT" "$MONITOR_JOB" | crontab -
+    fi
 
     print_success "Monitoring sistemleri kuruldu"
 }
@@ -699,8 +705,13 @@ EOF
 
     chmod +x /opt/backup-scripts/backup-vpn.sh
 
-    # Günlük yedekleme cron job'u
-    echo "0 2 * * * /opt/backup-scripts/backup-vpn.sh >> /var/log/backup.log" | crontab -
+    # Günlük yedekleme cron job'u (idempotent)
+    BACKUP_JOB="0 2 * * * /opt/backup-scripts/backup-vpn.sh >> /var/log/backup.log"
+    CRON_CONTENT=$(crontab -l 2>/dev/null)
+    if ! echo "$CRON_CONTENT" | grep -Fq "$BACKUP_JOB"; then
+        # Safely append the new job and pipe to crontab.
+        printf "%s\n%s\n" "$CRON_CONTENT" "$BACKUP_JOB" | crontab -
+    fi
 
     print_success "Yedekleme sistemi kuruldu"
 }


### PR DESCRIPTION
The setup script uses `echo '...' | crontab -` to add cron jobs for monitoring and backups. This command overwrites the entire crontab with the new job. Since the script sets up two different jobs, the second one overwrites the first, leaving only the backup job active.

This change modifies the logic to make it idempotent and non-destructive. It now reads the existing crontab content into a variable, checks if the job already exists, and if not, appends the new job to the existing content before loading it back into the crontab.

This ensures that:
1. Both the monitoring and backup cron jobs are present after running the script.
2. Running the script multiple times does not create duplicate cron jobs.