### PR TITLE
fix: URL-encode database password in setup script

### DIFF
--- a/ubuntu_setup.sh
+++ b/ubuntu_setup.sh
@@ -29,7 +29,8 @@ APP_INSTALL_DIR="/opt/ultimatevps"
 APP_SOURCE_DIR=$(pwd)
 DB_NAME="ultimatevps_db"
 DB_USER="ultimatevps_user"
-DB_PASS=$(openssl rand -base64 16) # Generate a random password
+DB_PASS_RAW=$(openssl rand -base64 16) # Generate a random password
+DB_PASS_ENCODED=$(echo -n "$DB_PASS_RAW" | node -p 'encodeURIComponent(require("fs").readFileSync(0, "utf-8").trim())')
 
 # --- Main Setup Function ---
 main() {
@@ -72,7 +73,7 @@ main() {
     print_status "Configuring PostgreSQL database..."
     systemctl enable --now postgresql
     sudo -u postgres psql -c "CREATE DATABASE $DB_NAME;" &>/dev/null
-    sudo -u postgres psql -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASS';" &>/dev/null
+    sudo -u postgres psql -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASS_RAW';" &>/dev/null
     sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;" &>/dev/null
     print_success "PostgreSQL database '$DB_NAME' and user '$DB_USER' created."
 
@@ -86,7 +87,7 @@ main() {
     JWT_SECRET=$(openssl rand -base64 32)
     cat > "$APP_INSTALL_DIR/.env" << EOF
 # --- Database Configuration ---
-DATABASE_URL="postgresql://$DB_USER:$DB_PASS@localhost:5432/$DB_NAME"
+DATABASE_URL="postgresql://$DB_USER:$DB_PASS_ENCODED@localhost:5432/$DB_NAME"
 
 # --- Application Settings ---
 JWT_SECRET="$JWT_SECRET"


### PR DESCRIPTION
The `ubuntu_setup.sh` script generates a random password for the PostgreSQL database. This password can contain special characters that are not valid in a URL, causing the `DATABASE_URL` to be malformed and Prisma migrations to fail.

This change fixes the issue by:
1. Generating a raw password and a separate URL-encoded version of it.
2. Using the raw password for the `psql` command to create the user, which expects a literal password.
3. Using the URL-encoded password in the `DATABASE_URL` inside the `.env` file, which ensures the connection string is always valid.