### PR TITLE
fix: URL-encode database password in setup script

### DIFF
--- a/ubuntu_setup.sh
+++ b/ubuntu_setup.sh
@@ -29,8 +29,7 @@ APP_INSTALL_DIR="/opt/ultimatevps"
 APP_SOURCE_DIR=$(pwd)
 DB_NAME="ultimatevps_db"
 DB_USER="ultimatevps_user"
-DB_PASS_RAW=$(openssl rand -base64 16) # Generate a random password
-DB_PASS_ENCODED=$(echo -n "$DB_PASS_RAW" | node -p 'encodeURIComponent(require("fs").readFileSync(0, "utf-8").trim())')
+DB_PASS=$(openssl rand -base64 16 | node -p 'encodeURIComponent(require("fs").readFileSync(0, "utf-8").trim())') # Generate and URL-encode a random password
 
 # --- Main Setup Function ---
 main() {
@@ -73,7 +72,7 @@ main() {
     print_status "Configuring PostgreSQL database..."
     systemctl enable --now postgresql
     sudo -u postgres psql -c "CREATE DATABASE $DB_NAME;" &>/dev/null
-    sudo -u postgres psql -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASS_RAW';" &>/dev/null
+    sudo -u postgres psql -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASS';" &>/dev/null
     sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;" &>/dev/null
     print_success "PostgreSQL database '$DB_NAME' and user '$DB_USER' created."
 
@@ -87,7 +86,7 @@ main() {
     JWT_SECRET=$(openssl rand -base64 32)
     cat > "$APP_INSTALL_DIR/.env" << EOF
 # --- Database Configuration ---
-DATABASE_URL="postgresql://$DB_USER:$DB_PASS_ENCODED@localhost:5432/$DB_NAME"
+DATABASE_URL="postgresql://$DB_USER:$DB_PASS@localhost:5432/$DB_NAME"
 
 # --- Application Settings ---
 JWT_SECRET="$JWT_SECRET"


### PR DESCRIPTION
The `ubuntu_setup.sh` script generates a random password for the PostgreSQL database. This password can contain special characters that are not valid in a URL, causing the `DATABASE_URL` to be malformed and Prisma migrations to fail.

This change fixes the issue by URL-encoding the generated password and using this encoded password for both the database user creation and the `DATABASE_URL` in the `.env` file. This ensures that the password stored in the database is the same as the one used in the connection string, resolving both the URL parsing and authentication errors.