### PR TITLE
fix: generate URL-safe database password

### DIFF
--- a/ubuntu_setup.sh
+++ b/ubuntu_setup.sh
@@ -29,7 +29,7 @@ APP_INSTALL_DIR="/opt/ultimatevps"
 APP_SOURCE_DIR=$(pwd)
 DB_NAME="ultimatevps_db"
 DB_USER="ultimatevps_user"
-DB_PASS=$(openssl rand -base64 16 | node -p 'encodeURIComponent(require("fs").readFileSync(0, "utf-8").trim())') # Generate and URL-encode a random password
+DB_PASS=$(openssl rand -hex 16) # Generate a URL-safe random password
 
 # --- Main Setup Function ---
 main() {


### PR DESCRIPTION
The setup script previously used `openssl rand -base64` to generate database passwords. This could produce passwords with special characters (`+`, `/`) that are not safe for use in a URL, causing Prisma to fail with either a URL parsing error or an authentication error.

This commit fixes the issue by changing the password generation method to `openssl rand -hex`. This produces a password containing only hexadecimal characters, which are inherently URL-safe. This approach is more robust as it eliminates the need for any URL encoding and ensures the password is always valid.