### PR TITLE
fix: make database setup script idempotent

### DIFF
--- a/ubuntu_setup.sh
+++ b/ubuntu_setup.sh
@@ -71,6 +71,12 @@ main() {
     # 5. Configure PostgreSQL
     print_status "Configuring PostgreSQL database..."
     systemctl enable --now postgresql
+    # Terminate any active connections to the database to allow it to be dropped.
+    sudo -u postgres psql -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$DB_NAME' AND pid <> pg_backend_pid();" &>/dev/null
+    # Drop user and database if they exist to ensure a clean slate
+    sudo -u postgres psql -c "DROP DATABASE IF EXISTS $DB_NAME;" &>/dev/null
+    sudo -u postgres psql -c "DROP USER IF EXISTS $DB_USER;" &>/dev/null
+    # Create the user and database
     sudo -u postgres psql -c "CREATE DATABASE $DB_NAME;" &>/dev/null
     sudo -u postgres psql -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASS';" &>/dev/null
     sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;" &>/dev/null


### PR DESCRIPTION
The `ubuntu_setup.sh` script was failing on re-runs because it was not idempotent. A previously failed run would leave a database user in place with an old password. Subsequent runs would generate a new password for the .env file, but would fail to update the user in the database, leading to an authentication error.

This commit fixes the issue by making the database setup section idempotent. It now performs the following actions before creating the database and user:
1. Terminates any active connections to the target database.
2. Drops the database if it exists.
3. Drops the user if it exists.

This ensures that every run of the script starts with a clean slate, preventing state-related errors from previous runs. The password generation also continues to use `openssl rand -hex` to avoid URL-unsafe characters.