### PR TITLE
fix: implement clean build and improve auth error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/server.js",
   "scripts": {
     "dev": "nodemon --watch src --exec ts-node src/server.ts",
-    "build": "tsc",
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc",
     "start": "node dist/server.js",
     "test": "jest",
     "v2ray": "ts-node src/v2ray-cli.ts",


### PR DESCRIPTION
This commit addresses two issues:

1.  **Implements a clean build process:** The `build` script in `package.json` has been updated to ensure the `dist` directory is removed before each compilation. This prevents issues with stale or old build artifacts causing unexpected behavior after code changes. A `clean` script (`rm -rf dist`) was added and is now called by the `build` script.

2.  **Improves auth error handling:** The error handling in the `login` and `registerAdmin` controllers has been enhanced. The code now specifically catches `Prisma.PrismaClientInitializationError`, which is thrown when the application cannot connect to the database. Instead of a generic error, it now returns a clear, actionable message, helping to diagnose environment and configuration problems.